### PR TITLE
Switch to CJS and provide ESM wrapper

### DIFF
--- a/esm/index.js
+++ b/esm/index.js
@@ -1,0 +1,3 @@
+
+import cjsModule from '../index.js';
+export default cjsModule;

--- a/esm/package.json
+++ b/esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-export default class D {
+
+class D {
 
 	constructor(size=32) {
 		const vs = size.buffer ? size : new Float64Array(size.byteLength ? size : 2*size)
@@ -201,3 +202,5 @@ function topIndex(arr, v, max) {
 	}
 	return max
 }
+
+module.exports = D;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "sample-distribution",
-  "type": "module",
   "main": "./index.js",
   "browser": "./index.js",
   "version": "1.3.1",


### PR DESCRIPTION
The module is currently written for ESM which makes it pretty impossible to use in CommonJS projects. This PR switches the module to CJS and provides a ESM wrapper.